### PR TITLE
The module appears to be compatible with 7.4.0 update the composer.js…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "imi/magento2-module-svg-product-images",
     "description": "",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0",
+        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0",
         "magento/magento-composer-installer": "*"
     },
     "suggest": {


### PR DESCRIPTION
It appears that your module is compatible with PHP 7.4. Magento 2.3.7-p2 (The latest 2.3 release) requires 7.4. This pull request updates your composer.json to list compatibility with PHP 7.4. I've tested the module with 7.4 as well, and it appears to work fine. 